### PR TITLE
Output full image name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: "(Optional) Extra arguments to pass to docker build"
     required: false
 
+outputs:
+  FULL_IMAGE_NAME:
+    description: Full name of the Docker Image with the Registry (if provided) and Namespace included
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -243,3 +243,5 @@ build_image
 tag_image
 push_image_and_stages
 logout_from_registry
+
+echo "::set-output name=FULL_IMAGE_NAME::$(_get_full_image_name)"

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Built-in support for the most known registries: Docker Hub, AWS ECR, GitHub's re
 
 ## Outputs
 
-None
+`FULL_IMAGE_NAME`: Full name of the Docker Image with the Registry (if provided) and Namespace included (e.g.: `docker.pkg.github.com/whoan/hello-world/hello-world`)
 
 ## How it works
 


### PR DESCRIPTION
Outputs the full image name (ie: `registry/namespace/image_name`) as it might be helpful for further steps of the job.