### PR TITLE
Add exit code for failed $INPUT_PUSH_IMAGE_AND_STAGES

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -214,7 +214,8 @@ push_image_and_stages() {
   echo -e "\n[Action Step] Pushing image..."
   if ! $INPUT_PUSH_IMAGE_AND_STAGES; then
     echo "Not pushing" >&2
-    return 1
+    [ $INPUT_PUSH_IMAGE_AND_STAGES = false ]
+    return
   fi
 
   if [ "$not_logged_in" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -214,7 +214,7 @@ push_image_and_stages() {
   echo -e "\n[Action Step] Pushing image..."
   if ! $INPUT_PUSH_IMAGE_AND_STAGES; then
     echo "Not pushing" >&2
-    return
+    return 1
   fi
 
   if [ "$not_logged_in" ]; then


### PR DESCRIPTION
My builds are green even when this part fails. Making me think I did a good job, but when I look at the logs I can see that it failed. This is just a suggestion though.