### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/sha8.sh
+++ b/.github/workflows/sha8.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-SHA8=$(echo ${GIT_SHA} | cut -c1-8)
-echo "SHA8: ${SHA8}"
-echo "::set-output name=sha8::${SHA8}"

--- a/.github/workflows/sha8.sh
+++ b/.github/workflows/sha8.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SHA8=$(echo ${GIT_SHA} | cut -c1-8)
+echo "SHA8: ${SHA8}"
+echo "::set-output name=sha8::${SHA8}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,7 @@ jobs:
       id: sha8
       env:
         GIT_SHA: ${{ github.sha }}
-      run: |
-        SHA8=$(echo ${GIT_SHA} | cut -c1-8)
-        echo "SHA8: ${SHA8}"
-        echo "::set-output name=sha8::${SHA8}"
+      run: ./.github/workflows/sha8.sh
 
     - uses: ./
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Provides nice code review annotations for problems discovered by
+    # shellcheck.
+    - uses: reviewdog/action-shellcheck@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        reporter: github-pr-review
+        level: info
+
+    # As `reviewdog/action-shellcheck` does not fail the build on `style`
+    # errors, run `bewuethr/shellcheck-action` as a precaution. Can be removed
+    # once `reviewdog/action-shellcheck` fails the build on the specified
+    # `severity`.
+    - uses: bewuethr/shellcheck-action@v2
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: SHA8
+      id: sha8
+      env:
+        GIT_SHA: ${{ github.sha }}
+      run: |
+        SHA8=$(echo ${GIT_SHA} | cut -c1-8)
+        echo "SHA8: ${SHA8}"
+        echo "::set-output name=sha8::${SHA8}"
+
+    - uses: ./
+      with:
+        password: "${{ secrets.GITHUB_TOKEN }}"
+        registry: docker.pkg.github.com
+        image_name: ${{ github.repository }}
+        image_tag: ${{ steps.sha8.outputs.sha8 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,5 @@ jobs:
         username: ${{ github.repository_owner }}
         password: "${{ secrets.GITHUB_TOKEN }}"
         registry: docker.pkg.github.com
-        image_name: ${{ github.repository }}
+        image_name: docker-build-with-cache-action
         push_git_tag: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,15 +31,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: SHA8
-      id: sha8
-      env:
-        GIT_SHA: ${{ github.sha }}
-      run: ./.github/workflows/sha8.sh
-
     - uses: ./
       with:
         password: "${{ secrets.GITHUB_TOKEN }}"
         registry: docker.pkg.github.com
         image_name: ${{ github.repository }}
-        image_tag: ${{ steps.sha8.outputs.sha8 }}
+        push_git_tag: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
 
     - uses: ./
       with:
+        username: ${{ github.repository_owner }}
         password: "${{ secrets.GITHUB_TOKEN }}"
         registry: docker.pkg.github.com
         image_name: ${{ github.repository }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that performs a [ShellCheck](https://www.shellcheck.net/) of the Bash scripts and also executes the action of this repository itself.

The former is just good form, I think, but the latter demonstrates a problem I have where the resulting image is always set to `my_awesome_image:latest` even though I'm sending in something explicitly different in both `image_name` and `image_tag`.

If this PR is accepted, I can help fix the problems reported by ShellCheck in this or a separate PR. I can also help fix the latter problem, unless it's a bug on my end, of course.