### PR TITLE
Add support for GCR subdomains (Like us.gcr.io)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ _is_github_registry() {
 }
 
 _is_gcloud_registry() {
-  [ "$INPUT_REGISTRY" = gcr.io ]
+  [[ "$INPUT_REGISTRY" =~ ^(.+\.)?gcr\.io$ ]]
 }
 
 _is_aws_ecr() {


### PR DESCRIPTION
Current functionality does not support GCR deployments if the registry is `us.gcr.io` or any other regional subdomain. This PR adds support for these subdomains.