### PR TITLE
Determine the GCR namespace with jq instead of sed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ _set_namespace() {
       NAMESPACE=$GITHUB_REPOSITORY
     elif _is_gcloud_registry; then
       # take project_id from Json Key
-      NAMESPACE=$(echo "${INPUT_PASSWORD}" | sed -rn 's@.+project_id" *: *"([^"]+).+@\1@p' 2> /dev/null)
+      NAMESPACE=$(jq -r '.project_id' <<< "$INPUT_PASSWORD" 2> /dev/null)
       [ "$NAMESPACE" ] || return 1
     fi
     # aws-ecr does not need a namespace


### PR DESCRIPTION
All GitHub runners have `jq` preinstalled and this should be easier to maintain than using a `sed` command