### PR TITLE
Get AWS_SESSION_TOKEN from the env if INPUT_SESSION is not set

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -164,7 +164,7 @@ _aws() {
   docker run --rm \
     --env AWS_ACCESS_KEY_ID="$INPUT_USERNAME" \
     --env AWS_SECRET_ACCESS_KEY="$INPUT_PASSWORD" \
-    --env AWS_SESSION_TOKEN="$INPUT_SESSION" \
+    --env AWS_SESSION_TOKEN="${INPUT_SESSION:-$AWS_SESSION_TOKEN}" \
     amazon/aws-cli:2.1.14 --region "$(_get_aws_region)" "$@"
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,7 +104,7 @@ _set_variables() {
 
   INPUT_IMAGE_NAME=${image_name%:*}
   if [ "$INPUT_REGISTRY" ]; then
-    INPUT_IMAGE_NAME=${INPUT_IMAGE_NAME#$INPUT_REGISTRY/}
+    INPUT_IMAGE_NAME=${INPUT_IMAGE_NAME#"$INPUT_REGISTRY"/}
   fi
 
   INPUT_CONTEXT=$(_get_context_by_service_name "$service_name")


### PR DESCRIPTION
@emmaai  Could you please test the action from this branch to see if it solves your issue?

    - uses: whoan/docker-build-with-cache-action@issue-108

Close #108 