### PR TITLE
Allow adding multiple values to same key in BUILD_EXTRA_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ or
   > :star2: New in v5.11.0: If you need extra args with newlines or spaces, use json format like this:  
     `build_extra_args: '{"--build-arg": "myarg=Hello\nWorld"}'`
 
+  > :star2: If you need multiple args with same key, use an array as the value of the key like this:  
+    `build_extra_args: '{"--build-arg": ["foo=bar", "one=two"]}'`
+
 - **push_image_and_stages**: Test a command before pushing. Use `false` to not push at all (default: `true`).
 
     This input also supports 2 special values, which are useful if your workflow can be triggered by different events:

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -223,13 +223,6 @@ _parse_extra_args() {
   INPUT_BUILD_EXTRA_ARGS=""
 }
 
-_remove_quotes() {
-  local param
-  param="${1:?I need a param}"
-  param="${param#\"}"
-  echo "${param%\"}"
-}
-
 # action steps
 init_variables() {
   DUMMY_IMAGE_NAME=my_awesome_image

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -210,16 +210,16 @@ _parse_extra_args() {
   fi
 
   # json
-  declare -ga extra_args
+  declare -ga extra_args=()
   local key
   local value
   while read -r key; do
-    value=$(_remove_quotes "$(jq ".$key" <<<"${INPUT_BUILD_EXTRA_ARGS}")")
-    key=$(_remove_quotes "$key")
-    extra_args+=("$key")
-    extra_args+=("${value//\\n/
+    for value in $(jq --raw-output "[.\"$key\"] | flatten[]" <<<"${INPUT_BUILD_EXTRA_ARGS}"); do
+      extra_args+=("$key")
+      extra_args+=("${value//\\n/
 }")
-  done < <(jq "keys[]" <<<"${INPUT_BUILD_EXTRA_ARGS}")
+    done
+  done < <(jq --raw-output "keys[]" <<<"${INPUT_BUILD_EXTRA_ARGS}")
   INPUT_BUILD_EXTRA_ARGS=""
 }
 


### PR DESCRIPTION
Allow `build_extra_args` to have multiple values for same key through a json array like this:

    build_extra_args: '{"--build-arg": ["foo=bar", "one=two"], "--target": "one-target"}'

That will expand to this in the `docker build` statement:

    --build-arg foo=bar --build-arg one=two --target one-target 

Test result: https://github.com/whoan/hello-world/actions/runs/3285309234/jobs/5412266018#step:4:121

Close #95