### PR TITLE
Use dummy tag instead of dummy image name

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -225,7 +225,7 @@ _parse_extra_args() {
 
 # action steps
 init_variables() {
-  DUMMY_IMAGE_NAME=my_awesome_image
+  DUMMY_IMAGE_NAME="$INPUT_IMAGE_NAME":tmp_tag_ignore
   BUILD_LOG=build-output.log
   # split tags (to allow multiple comma-separated tags)
   IFS=, read -ra INPUT_IMAGE_TAG <<< "$INPUT_IMAGE_TAG"


### PR DESCRIPTION
Close #106 

Test result with new output: https://github.com/whoan/hello-world/actions/runs/3304953549/jobs/5454717838#step:5:80

    Successfully tagged hello-world-multi-tag:tmp_tag_ignore

    [Action Step] Tagging image...
    Tag: whoan/hello-world-multi-tag:one
    Tag: whoan/hello-world-multi-tag:two
    Tag: whoan/hello-world-multi-tag:three