### PR TITLE
Check if repo exists before calling create-repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Find working minimal examples for the most known registries in [this repo](https
 
 ### AWS ECR
 
-> You don't even need to create the repositories in advance, as this action takes care of that for you!
+> You don't even need to create the repositories in advance, as this action takes care of that for you! (you'll need the `CreateRepository` permission)
 
 ```yml
 - uses: whoan/docker-build-with-cache-action@v5

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -223,7 +223,7 @@ _create_aws_ecr_repos() {
   local main_repo stages_repo
   main_repo=$INPUT_IMAGE_NAME stages_repo=$(_get_stages_image_name)
   for repo in "$main_repo" "$stages_repo"; do
-    _aws_repo_exists "$repo" || _aws "$(_aws_ecr)" create-repository --repository-name "$repo"
+    _aws_repo_exists "$repo" || _aws "$(_aws_ecr)" create-repository --repository-name "$repo" || return 1
   done
 }
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -219,9 +219,6 @@ _aws_repo_exists() {
 }
 
 _create_aws_ecr_repos() {
-  if ! _must_push; then
-    return 0
-  fi
   echo -e "\n[Action Step - AWS] Creating repositories (if needed)..."
   local main_repo stages_repo
   main_repo=$INPUT_IMAGE_NAME stages_repo=$(_get_stages_image_name)
@@ -311,6 +308,9 @@ login_to_registry() {
 
 create_repos() {
   if [ "$not_logged_in" == true ]; then
+    return
+  fi
+  if ! _must_push; then
     return
   fi
   if _is_aws_ecr; then

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -203,7 +203,7 @@ _create_aws_ecr_repos() {
 
 _docker_login() {
   if _is_aws_ecr; then
-    { _login_to_aws_ecr && _create_aws_ecr_repos; } || return 1
+    _login_to_aws_ecr || return 1
   else
     echo "${INPUT_PASSWORD}" | docker login -u "${INPUT_USERNAME}" --password-stdin "${INPUT_REGISTRY}" || return 1
   fi
@@ -278,6 +278,15 @@ login_to_registry() {
   fi
   not_logged_in=true
   echo "INFO: Won't be able to pull from private repos, nor to push to public/private repos" >&2
+}
+
+create_repos() {
+  if [ "$not_logged_in" == true ]; then
+    return
+  fi
+  if _is_aws_ecr; then
+    _create_aws_ecr_repos || return 1
+  fi
 }
 
 pull_cached_stages() {
@@ -367,6 +376,7 @@ check_aws_cli
 init_variables
 check_required_input
 login_to_registry
+create_repos
 pull_cached_stages
 build_image
 tag_image


### PR DESCRIPTION
Close #120 

I removed `ecr:CreateRepository` and `ecr-public:CreateRepository` permissions and I see a cleaner output now when the repo already exists.

Tets result: https://github.com/whoan/hello-world/actions/runs/3979315587