### PR TITLE
Use context input as a prefix for the context from compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ or
 - **image_tag**: Tag(s) of the image. Allows multiple comma-separated tags (e.g. `one,another`) (default: `latest`).  
   If you set **compose_file** and the image(s) already has/have a tag, this is ignored.
 
+- **context**: Docker context (default: `./`). If a **compose_file** is provided, it will be the context prefixed to any additional context read from the compose file. Look at #133 for more details.
+
 - **registry**: Docker registry (default: *Docker Hub's registry*). You need a registry to use the cache functionality.
 
 - **username**: Docker registry's user (needed to push images, or to pull from a private repository).
@@ -67,8 +69,6 @@ or
 #### Ignored if `compose_file` is set
 
 - **image_name**
-
-- **context**: Docker context (default: `./`).
 
 - **dockerfile**: Dockerfile filename path (default: `"$context"/Dockerfile`).
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ fi
 
 merged_compose=/tmp/merged-compose.yml
 original_INPUT_IMAGE_TAG=$INPUT_IMAGE_TAG
+original_INPUT_CONTEXT=$INPUT_CONTEXT
 
 build_from_compose_file() {
    echo -e "\nBuilding from Compose file(s)"
@@ -95,7 +96,7 @@ _set_variables() {
   fi
 
   INPUT_CONTEXT=$(_get_context_by_service_name "$service_name")
-  INPUT_CONTEXT=${INPUT_CONTEXT:-.}
+  INPUT_CONTEXT=$original_INPUT_CONTEXT/${INPUT_CONTEXT:-.}
 
   INPUT_DOCKERFILE=$(_get_dockerfile_by_service_name "$service_name")
   INPUT_DOCKERFILE=${INPUT_DOCKERFILE:-Dockerfile}


### PR DESCRIPTION
Closes #133

Good catch @Clashsoft

Test: https://github.com/whoan/hello-world/pull/12

Test 1: Fails (as expected) when I don't provide the context to be used when processing the compose file: https://github.com/whoan/hello-world/actions/runs/6523592786/job/17714377588

Test 2: It is solved when I use `context` which now means "context for compose file": https://github.com/whoan/hello-world/actions/runs/6523600020/job/17714393215

