### PR TITLE
Allow overriding DOCKER_BUILDKIT env var

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-export DOCKER_BUILDKIT=0
 set -e
+export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-0}
 
 # helper functions
 _has_value() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-export DOCKER_BUILDKIT=0
 set -e
 
 _build_image() {


### PR DESCRIPTION
Close #139

Tesst in https://github.com/whoan/hello-world/pull/15

As you can see there, after subsequent builds:

- The one **with DOCKER_BUILDKIT** enabled, **does NOT use the cache**. ie: it builds from scratch, but fast thanks to the new builder
- The one **without DOCKER_BUILDKIT** enabled, does **use the cache** which makes it fast after the first build.

For the moments, those will be the options, until I can find a way to always use DOCKER_BUILDKIT and still use the cache in #138 .