### PR TITLE
Honour custom cache image name in public AWS ECR when BuildKit is disabled

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -178,7 +178,7 @@ _aws_get_public_ecr_registry_name() {
 }
 
 _aws_get_image_tags() {
-  mapfile -t tags < <(_aws ecr-public describe-image-tags --repository-name "$INPUT_IMAGE_NAME"-stages | jq ".imageTagDetails[].imageTag")
+  mapfile -t tags < <(_aws ecr-public describe-image-tags --repository-name "$(_get_stages_image_name)" | jq ".imageTagDetails[].imageTag")
   tags=( "${tags[@]#\"}" )
   tags=( "${tags[@]%\"}" )
 }


### PR DESCRIPTION
Close #146 

Test: https://github.com/whoan/hello-world/actions/runs/6676646231/job/18145991582#step:4:64