### PR TITLE
Use aws-cli from base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM docker:24.0.7
 LABEL "maintainer"="whoan <juaneabadie@gmail.com>"
 LABEL "repository"="https://github.com/whoan/docker-build-with-cache-action"
 
+RUN apk add --no-cache bash grep jq yq aws-cli
+
 COPY docker-build.sh /docker-build.sh
 COPY entrypoint.sh /entrypoint.sh
-
-RUN apk add --no-cache bash grep jq yq
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -180,13 +180,12 @@ _push_image_stages() {
   docker push "$stage_image"
 }
 
-_aws() {
-  docker run --rm \
-    --env AWS_ACCESS_KEY_ID="$INPUT_USERNAME" \
-    --env AWS_SECRET_ACCESS_KEY="$INPUT_PASSWORD" \
-    --env AWS_SESSION_TOKEN="$INPUT_SESSION" \
-    amazon/aws-cli:2.1.14 --region "$(_get_aws_region)" "$@"
-}
+_aws() (
+  export AWS_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY
+  export AWS_SESSION_TOKEN
+  aws --region "$(_get_aws_region)" "$@"
+)
 
 _aws_get_public_ecr_registry_name() {
   _aws ecr-public describe-registries --output=text --query 'registries[0].aliases[0].name'
@@ -294,6 +293,9 @@ init_variables() {
     if [ -z "$INPUT_SESSION" ]; then
         INPUT_SESSION=$AWS_SESSION_TOKEN
     fi
+    AWS_ACCESS_KEY_ID=$INPUT_USERNAME
+    AWS_SECRET_ACCESS_KEY=$INPUT_PASSWORD
+    AWS_SESSION_TOKEN=$INPUT_SESSION
   fi
 
   # split tags (to allow multiple comma-separated tags)


### PR DESCRIPTION
Reduce build time by using base image's aws-cli instead of getting it from docker.

test: https://github.com/whoan/hello-world/actions/runs/6677925016