### PR TITLE
Name builder instance to avoid multiple ones on self-hosted runners

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -411,7 +411,7 @@ _build_image_buildkit() {
   _parse_extra_args
 
   set -x
-  docker buildx create --use
+  docker buildx create --use --name action-builder-instance |& grep -v "existing instance" || true
   # shellcheck disable=SC2086
   docker buildx build \
     --load \


### PR DESCRIPTION
Close #151 

If you are running self-hosted runners, you may need to clean some stale builder instances created by v8.0.0 of the action. To do so, you can run something like this (review and use with caution):

    docker buildx ls \
        | grep -E "^[^ ].+ docker-container" \
        | while read -r instance_name rest; do docker buildx rm "$instance_name"; done

FYI @milandufek ^