### PR TITLE
Add Support for Google Cloud Artifact Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Find working minimal examples for the most known registries in [this repo](https
 
 ### Google Cloud Artifact Registry
 
+> More info [here](https://cloud.google.com/artifact-registry/docs/docker/names) on Google Cloud repository and image names.
+
 ```yml
 # https://github.com/google-github-actions/auth
 - uses: google-github-actions/auth@v2

--- a/README.md
+++ b/README.md
@@ -137,7 +137,29 @@ Find working minimal examples for the most known registries in [this repo](https
     image_name: hello-world
 ```
 
-### Google Cloud Registry
+### Google Cloud Artifact Registry
+
+```yml
+# https://github.com/google-github-actions/auth
+- uses: google-github-actions/auth@v2
+  id: auth
+  with:
+    token_format: access_token
+    workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+    service_account: ${{ secrets.SERVICE_ACCOUNT }}
+
+- uses: whoan/docker-build-with-cache-action@v5
+  with:
+    username: whoan
+    password: ${{ steps.auth.outputs.access_token }}
+    # Docker repository
+    registry: us-west1-docker.pkg.dev/my-project/my-repo
+    # Domain-scoped project 
+    # registry: us-west1-docker.pkg.dev/example.com/my-project/my-repo
+    image_name: hello-world
+```
+
+### Google Cloud Container Registry
 
 > More info [here](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key) on how to get GCloud JSON key.
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -25,7 +25,7 @@ _is_new_github_registry() {
   [ "$INPUT_REGISTRY" = ghcr.io ]
 }
 
-_is_gcloud_registry() {
+_is_gcloud_container_registry() {
   [[ "$INPUT_REGISTRY" =~ ^(.+\.)?gcr\.io$ ]]
 }
 
@@ -62,7 +62,7 @@ _set_namespace() {
       NAMESPACE=${INPUT_USERNAME:?A username is needed if no namespace is provided}
     elif _is_old_github_registry; then
       NAMESPACE=$GITHUB_REPOSITORY
-    elif _is_gcloud_registry; then
+    elif _is_gcloud_container_registry; then
       # take project_id from Json Key
       NAMESPACE=$(echo "${INPUT_PASSWORD}" | sed -rn 's@.+project_id" *: *"([^"]+).+@\1@p' 2> /dev/null)
       [ "$NAMESPACE" ] || return 1

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -73,8 +73,6 @@ _set_namespace() {
       # take project_id from Json Key
       NAMESPACE=$(echo "${INPUT_PASSWORD}" | sed -rn 's@.+project_id" *: *"([^"]+).+@\1@p' 2> /dev/null)
       [ "$NAMESPACE" ] || return 1
-    if _is_gcloud_artifact_registry; then
-      NAMESPACE=$INPUT_REGISTRY
     elif _is_aws_ecr_public; then
       NAMESPACE=$(_aws_get_public_ecr_registry_name)
     fi
@@ -309,6 +307,11 @@ init_variables() {
 
   # split tags (to allow multiple comma-separated tags)
   IFS=, read -ra INPUT_IMAGE_TAG <<< "$INPUT_IMAGE_TAG"
+
+  if _is_gcloud_artifact_registry; then
+    return
+  fi
+
   if ! _set_namespace; then
     echo "Could not set namespace" >&2
     exit 1

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -25,6 +25,13 @@ _is_new_github_registry() {
   [ "$INPUT_REGISTRY" = ghcr.io ]
 }
 
+_is_gcloud_artifact_registry() {
+  # Docker repository: https://cloud.google.com/artifact-registry/docs/docker/names#docker-repo
+  # Domain-scoped project: https://cloud.google.com/artifact-registry/docs/docker/names#domain
+  [[ "$INPUT_REGISTRY" =~ ([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-]+)\/([a-z0-9-]+) ]] \
+  || [[ "$INPUT_REGISTRY" =~ ([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-]+)\/([a-z0-9-]+)\/([a-z0-9-]+) ]]
+}
+
 _is_gcloud_container_registry() {
   [[ "$INPUT_REGISTRY" =~ ^(.+\.)?gcr\.io$ ]]
 }
@@ -66,6 +73,8 @@ _set_namespace() {
       # take project_id from Json Key
       NAMESPACE=$(echo "${INPUT_PASSWORD}" | sed -rn 's@.+project_id" *: *"([^"]+).+@\1@p' 2> /dev/null)
       [ "$NAMESPACE" ] || return 1
+    if _is_gcloud_artifact_registry; then
+      NAMESPACE=$INPUT_REGISTRY
     elif _is_aws_ecr_public; then
       NAMESPACE=$(_aws_get_public_ecr_registry_name)
     fi

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -28,8 +28,8 @@ _is_new_github_registry() {
 _is_gcloud_artifact_registry() {
   # Docker repository: https://cloud.google.com/artifact-registry/docs/docker/names#docker-repo
   # Domain-scoped project: https://cloud.google.com/artifact-registry/docs/docker/names#domain
-  [[ "$INPUT_REGISTRY" =~ ([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-]+)\/([a-z0-9-]+) ]] \
-  || [[ "$INPUT_REGISTRY" =~ ([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-.]+)\/([a-z0-9-]+)\/([a-z0-9-]+) ]]
+  [[ "$INPUT_REGISTRY" =~ ^([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-]+)\/([a-z0-9-]+)$ ]] \
+  || [[ "$INPUT_REGISTRY" =~ ^([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-.]+)\/([a-z0-9-]+)\/([a-z0-9-]+)$ ]]
 }
 
 _is_gcloud_container_registry() {

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -29,7 +29,7 @@ _is_gcloud_artifact_registry() {
   # Docker repository: https://cloud.google.com/artifact-registry/docs/docker/names#docker-repo
   # Domain-scoped project: https://cloud.google.com/artifact-registry/docs/docker/names#domain
   [[ "$INPUT_REGISTRY" =~ ([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-]+)\/([a-z0-9-]+) ]] \
-  || [[ "$INPUT_REGISTRY" =~ ([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-]+)\/([a-z0-9-]+)\/([a-z0-9-]+) ]]
+  || [[ "$INPUT_REGISTRY" =~ ([a-z0-9-]+)-docker.pkg.dev\/([a-z0-9-.]+)\/([a-z0-9-]+)\/([a-z0-9-]+) ]]
 }
 
 _is_gcloud_container_registry() {


### PR DESCRIPTION
Issue: https://github.com/whoan/docker-build-with-cache-action/issues/158

## Description

This adds the ability to specify a Google Cloud Artifact Registry repository and image with this action. Specifically:
- [Container image names](https://cloud.google.com/artifact-registry/docs/docker/names#containers)
- [Domain-scoped projects](https://cloud.google.com/artifact-registry/docs/docker/names#domain)
  - As a follow-up enhancement, we might want to consider adding support for [`image_digest`](https://cloud.google.com/artifact-registry/docs/docker/names#containers) as a potential input. Instead of `image_name:image_tag`, you can specify `image_name@image_digest`.