### PR TITLE
add custom tag for stages image, for build-kit only

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ or
 - **stages_image_name**: Set custom name for stages/cache image (default: `${image_name}-stages`). 
 
 - **stages_image_tag**: Set custom tag for the stages/cache image. (default: latest)"
-    requires: false
+    required: false
 
 - **push_image_and_stages**: Test a command before pushing. Use `false` to not push at all (default: `true`).
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ or
 
 - **stages_image_name**: Set custom name for stages/cache image (default: `${image_name}-stages`). 
 
-- **stages_image_tag**: Set custom tag for the stages/cache image. Only for buildkit. (deafult: latest)"
+- **stages_image_tag**: Set custom tag for the stages/cache image. (default: latest)"
     requires: false
 
 - **push_image_and_stages**: Test a command before pushing. Use `false` to not push at all (default: `true`).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ or
 
 - **pull_image_and_stages**: Set to `false` to avoid pulling from the registry or to build from scratch (default: `true`).
 
-- **stages_image_name**: Set custom name for stages/cache image (default: `${image_name}-stages`). Tags are ignored.
+- **stages_image_name**: Set custom name for stages/cache image (default: `${image_name}-stages`). 
+
+- **stages_image_tag**: Set custom tag for the stages/cache image. Only for buildkit. (deafult: latest)"
+    requires: false
 
 - **push_image_and_stages**: Test a command before pushing. Use `false` to not push at all (default: `true`).
 

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,9 @@ inputs:
   stages_image_name:
     description: "(Optional) Use a custom name for the stages. Useful if using a job matrix (default: ${image_name}-stages)"
     required: false
+  stages_image_tag:
+    description: "(Optional) Use a custom tag for the stages image. Only for buildkit. (deafult: latest)"
+    requires: false
   push_git_tag:
     description: "(Optional) In addition to `image_tag` value, you can also push current git tag (default: false)"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -46,8 +46,8 @@ inputs:
     description: "(Optional) Use a custom name for the stages. Useful if using a job matrix (default: ${image_name}-stages)"
     required: false
   stages_image_tag:
-    description: "(Optional) Use a custom tag for the stages image. Only for buildkit. (deafult: latest)"
-    requires: false
+    description: "(Optional) Use a custom tag for the stages image. (default: latest)"
+    required: false
   push_git_tag:
     description: "(Optional) In addition to `image_tag` value, you can also push current git tag (default: false)"
     required: false

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -171,7 +171,7 @@ _push_image_stages() {
   local stage_image
   for stage in $(_get_stages); do
     echo -e "\nPushing stage: $stage_number"
-    stage_image=$(_get_full_stages_image_name):$stage_number
+    stage_image=$(_get_full_stages_image_name):"$(_get_stages_image_tag)"-$stage_number
     docker tag "$stage" "$stage_image"
     docker push "$stage_image"
     stage_number=$(( stage_number+1 ))
@@ -179,7 +179,7 @@ _push_image_stages() {
 
   # push the image itself as a stage (the last one)
   echo -e "\nPushing stage: $stage_number"
-  stage_image=$(_get_full_stages_image_name):$stage_number
+  stage_image=$(_get_full_stages_image_name):"$(_get_stages_image_tag)"-$stage_number
   docker tag "$DUMMY_IMAGE_NAME" "$stage_image"
   docker push "$stage_image"
 }

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -96,9 +96,13 @@ _get_stages_image_name() {
   echo "${INPUT_STAGES_IMAGE_NAME:-${INPUT_IMAGE_NAME}-stages}"
 }
 
+_get_stages_image_tag() {
+  echo "${INPUT_STAGES_IMAGE_TAG:-latest}"
+}
+
 _get_full_stages_image_name() {
   echo "$(_get_image_namespace)$(_get_stages_image_name)"
-}
+} 
 
 _tag() {
   local tag
@@ -396,7 +400,7 @@ _build_image_buildkit() {
   echo -e "\n[Action Step] Building image with BuildKit..."
 
   local cache_image
-  cache_image="$(_get_full_stages_image_name)":latest
+  cache_image="$(_get_full_stages_image_name)":"$(_get_stages_image_tag)"
 
   local cache_from
   if _can_pull; then


### PR DESCRIPTION
This PR supposed to fix the issue #157 and allow custom tag naming for the stages/cache image for build kit.