### PR TITLE
CI: give job package write permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
     - uses: bewuethr/shellcheck-action@v2
 
   docker:
+    permissions:
+      packages: write
     name: Docker
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This change, or the more severe
"permissions: write-all" will make
the CI jobs triggered by Dependabot
pass when writing Docker cache
to ghcr.io.